### PR TITLE
Use chain_info.seconds_per_slot instead of 12 seconds constant

### DIFF
--- a/crates/api/src/builder/api.rs
+++ b/crates/api/src/builder/api.rs
@@ -13,7 +13,7 @@ use axum::{
     Extension,
 };
 use ethereum_consensus::{
-    configs::mainnet::{CAPELLA_FORK_EPOCH, SECONDS_PER_SLOT},
+    configs::mainnet::CAPELLA_FORK_EPOCH,
     phase0::mainnet::SLOTS_PER_EPOCH,
     primitives::{BlsPublicKey, Hash32},
     ssz::{self, prelude::*},
@@ -1646,7 +1646,7 @@ fn sanity_check_block_submission(
     payload_attributes: &PayloadAttributesUpdate,
     chain_info: &ChainInfo,
 ) -> Result<(), BuilderApiError> {
-    let expected_timestamp = chain_info.genesis_time_in_secs + (bid_trace.slot * SECONDS_PER_SLOT);
+    let expected_timestamp = chain_info.genesis_time_in_secs + (bid_trace.slot * chain_info.seconds_per_slot);
     if payload.timestamp() != expected_timestamp {
         return Err(BuilderApiError::IncorrectTimestamp { got: payload.timestamp(), expected: expected_timestamp });
     }

--- a/crates/housekeeper/src/chain_event_updater.rs
+++ b/crates/housekeeper/src/chain_event_updater.rs
@@ -4,11 +4,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use ethereum_consensus::{
-    configs::{goerli::CAPELLA_FORK_EPOCH, mainnet::SECONDS_PER_SLOT},
-    deneb::Withdrawal,
-    primitives::Bytes32,
-};
+use ethereum_consensus::{configs::goerli::CAPELLA_FORK_EPOCH, deneb::Withdrawal, primitives::Bytes32};
 use helix_beacon_client::{
     bellatrix::HashTreeRoot,
     types::{HeadEventData, PayloadAttributes, PayloadAttributesEvent},
@@ -131,7 +127,7 @@ impl<D: DatabaseService> ChainEventUpdater<D> {
 
         // Validate this isn't a faulty head slot
         if let Ok(current_timestamp) = SystemTime::now().duration_since(UNIX_EPOCH) {
-            let slot_timestamp = self.chain_info.genesis_time_in_secs + (event.slot * SECONDS_PER_SLOT);
+            let slot_timestamp = self.chain_info.genesis_time_in_secs + (event.slot * self.chain_info.seconds_per_slot);
             if slot_timestamp > current_timestamp.as_secs() + MAX_DISTANCE_FOR_FUTURE_SLOT {
                 warn!(head_slot = event.slot, "head event slot is too far in the future",);
                 return;


### PR DESCRIPTION
sync from https://github.com/gattaca-com/helix/pull/40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new method for optimistic block submissions, enhancing submission requirements and regional filtering.
	- Enhanced timestamp calculation for block submissions, improving flexibility.
	- Improved error handling for payload and header submissions, now supporting GZIP-compressed data.

- **Bug Fixes**
	- Added checks for duplicate block hashes in message processing to prevent errors.

- **Refactor**
	- Streamlined import statements and updated method logic to utilize properties of the `ChainInfo` struct for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->