### PR TITLE
Fix signature verify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2607,6 +2607,8 @@ version = "0.0.1"
 dependencies = [
  "axum 0.7.7",
  "ethereum-consensus 0.1.1 (git+https://github.com/ralexstokes/ethereum-consensus?rev=cf3c404043230559660810bc0c9d6d5a8498d819)",
+ "helix-common",
+ "hex",
  "http 1.1.0",
  "reqwest",
  "reth-primitives 1.0.7",

--- a/crates/api/src/proposer/api.rs
+++ b/crates/api/src/proposer/api.rs
@@ -904,7 +904,6 @@ where
             &mut election_req.message,
             &election_req.signature,
             &proposer_pub_key,
-            Some(head_slot),
             Some(self.chain_info.genesis_validators_root),
             &self.chain_info.context,
         ) {

--- a/crates/common/src/api/constraints_api.rs
+++ b/crates/common/src/api/constraints_api.rs
@@ -44,13 +44,13 @@ impl SignedPreconferElection {
 #[derive(Debug, Default, Clone, SimpleSerialize, serde::Serialize, serde::Deserialize)]
 pub struct PreconferElection {
     /// Public key of the preconfer proposing for `slot`.
-    preconfer_pubkey: BlsPublicKey,
+    pub preconfer_pubkey: BlsPublicKey,
     /// Slot this delegation is valid for.
-    slot_number: u64,
+    pub slot_number: u64,
     /// Chain ID of the chain this election is for.
-    chain_id: u64,
-    // The gas limit specified by the proposer that the preconfer must adhere to.
-    gas_limit: u64,
+    pub chain_id: u64,
+    /// The gas limit specified by the proposer that the preconfer must adhere to.
+    pub gas_limit: u64,
 }
 
 impl PreconferElection {

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -19,3 +19,7 @@ reth-primitives.workspace = true
 http.workspace = true
 reqwest.workspace = true
 axum.workspace = true
+
+[dev-dependencies]
+helix-common = { workspace = true }
+hex = { workspace = true }

--- a/crates/utils/src/signing.rs
+++ b/crates/utils/src/signing.rs
@@ -46,11 +46,9 @@ pub fn verify_signed_commit_boost_message<T: HashTreeRoot>(
     message: &mut T,
     signature: &BlsSignature,
     public_key: &BlsPublicKey,
-    _slot_hint: Option<Slot>,
     root_hint: Option<Root>,
     context: &Context,
 ) -> Result<(), Error> {
-    // let fork_version = slot_hint.map(|slot| context.fork_version_for(context.fork_for(slot)));
     let fork_version = context.genesis_fork_version;
     let domain = compute_commit_boost_domain(Some(fork_version), root_hint, context)?;
     verify_signed_data(message, signature, public_key, domain)?;


### PR DESCRIPTION
This is a temporary fix, further discussion on https://github.com/Commit-Boost/commit-boost-client/issues/157

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced visibility of fields in the `PreconferElection` struct for easier access.
	- Added new methods in the `ProposerApi` for managing constraints and elections: `set_constraints` and `elect_preconfer`.
	- Added new development dependencies for improved functionality.

- **Bug Fixes**
	- Simplified logic in the `verify_signed_commit_boost_message` function for better performance.

- **Tests**
	- Introduced a new test module to verify the signature of `PreconferElection` messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->