### PR TITLE
feat: add onchain delegation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
+ "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -89,6 +90,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-consensus"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ed961a48297c732a5d97ee321aa8bb5009ecadbcb077d8bec90cb54e651629"
+dependencies = [
+ "alloy-eips 0.5.4",
+ "alloy-primitives 0.8.8",
+ "alloy-rlp",
+ "alloy-serde 0.5.4",
+ "auto_impl",
+ "c-kzg",
+ "derive_more 1.0.0",
+ "serde",
+]
+
+[[package]]
+name = "alloy-contract"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460ab80ce4bda1c80bcf96fe7460520476f2c7b734581c6567fac2708e2a60ef"
+dependencies = [
+ "alloy-dyn-abi",
+ "alloy-json-abi",
+ "alloy-network",
+ "alloy-network-primitives 0.5.4",
+ "alloy-primitives 0.8.8",
+ "alloy-provider",
+ "alloy-rpc-types-eth 0.5.4",
+ "alloy-sol-types 0.8.8",
+ "alloy-transport",
+ "futures",
+ "futures-util",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-dyn-abi"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6228abfc751a29cde117b0879b805a3e0b3b641358f063272c83ca459a56886"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives 0.8.8",
+ "alloy-sol-type-parser",
+ "alloy-sol-types 0.8.8",
+ "const-hex",
+ "itoa",
+ "serde",
+ "serde_json",
+ "winnow",
+]
+
+[[package]]
 name = "alloy-eip2930"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,6 +162,18 @@ dependencies = [
  "alloy-primitives 0.8.8",
  "alloy-rlp",
  "k256 0.13.4",
+ "serde",
+]
+
+[[package]]
+name = "alloy-eip7702"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ffc577390ce50234e02d841214b3dc0bea6aaaae8e04bbf3cb82e9a45da9eb"
+dependencies = [
+ "alloy-primitives 0.8.8",
+ "alloy-rlp",
+ "derive_more 1.0.0",
  "serde",
 ]
 
@@ -139,10 +205,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f923dd5fca5f67a43d81ed3ebad0880bd41f6dd0ada930030353ac356c54cd0f"
 dependencies = [
  "alloy-eip2930",
- "alloy-eip7702",
+ "alloy-eip7702 0.1.1",
  "alloy-primitives 0.8.8",
  "alloy-rlp",
  "alloy-serde 0.3.6",
+ "c-kzg",
+ "derive_more 1.0.0",
+ "once_cell",
+ "serde",
+ "sha2 0.10.8",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b69e06cf9c37be824b9d26d6d101114fdde6af0c87de2828b414c05c4b3daa71"
+dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702 0.3.2",
+ "alloy-primitives 0.8.8",
+ "alloy-rlp",
+ "alloy-serde 0.5.4",
  "c-kzg",
  "derive_more 1.0.0",
  "once_cell",
@@ -173,6 +257,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-json-abi"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d46eb5871592c216d39192499c95a99f7175cb94104f88c307e6dc960676d9f1"
+dependencies = [
+ "alloy-primitives 0.8.8",
+ "alloy-sol-type-parser",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-json-rpc"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af5979e0d5a7bf9c7eb79749121e8256e59021af611322aee56e77e20776b4b3"
+dependencies = [
+ "alloy-primitives 0.8.8",
+ "alloy-sol-types 0.8.8",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-network"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "204237129086ce5dc17a58025e93739b01b45313841f98fa339eb1d780511e57"
+dependencies = [
+ "alloy-consensus 0.5.4",
+ "alloy-eips 0.5.4",
+ "alloy-json-rpc",
+ "alloy-network-primitives 0.5.4",
+ "alloy-primitives 0.8.8",
+ "alloy-rpc-types-eth 0.5.4",
+ "alloy-serde 0.5.4",
+ "alloy-signer",
+ "alloy-sol-types 0.8.8",
+ "async-trait",
+ "auto_impl",
+ "futures-utils-wasm",
+ "thiserror",
+]
+
+[[package]]
 name = "alloy-network-primitives"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,6 +312,19 @@ dependencies = [
  "alloy-eips 0.3.6",
  "alloy-primitives 0.8.8",
  "alloy-serde 0.3.6",
+ "serde",
+]
+
+[[package]]
+name = "alloy-network-primitives"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "514f70ee2a953db21631cd817b13a1571474ec77ddc03d47616d5e8203489fde"
+dependencies = [
+ "alloy-consensus 0.5.4",
+ "alloy-eips 0.5.4",
+ "alloy-primitives 0.8.8",
+ "alloy-serde 0.5.4",
  "serde",
 ]
 
@@ -241,6 +385,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-provider"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4814d141ede360bb6cd1b4b064f1aab9de391e7c4d0d4d50ac89ea4bc1e25fbd"
+dependencies = [
+ "alloy-chains",
+ "alloy-consensus 0.5.4",
+ "alloy-eips 0.5.4",
+ "alloy-json-rpc",
+ "alloy-network",
+ "alloy-network-primitives 0.5.4",
+ "alloy-primitives 0.8.8",
+ "alloy-rpc-client",
+ "alloy-rpc-types-eth 0.5.4",
+ "alloy-transport",
+ "alloy-transport-http",
+ "async-stream",
+ "async-trait",
+ "auto_impl",
+ "dashmap",
+ "futures",
+ "futures-utils-wasm",
+ "lru",
+ "parking_lot",
+ "pin-project",
+ "reqwest",
+ "schnellru",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
 name = "alloy-rlp"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,6 +441,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.79",
+]
+
+[[package]]
+name = "alloy-rpc-client"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc2bd1e7403463a5f2c61e955bcc9d3072b63aa177442b0f9aa6a6d22a941e3"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-primitives 0.8.8",
+ "alloy-transport",
+ "alloy-transport-http",
+ "futures",
+ "pin-project",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.1",
+ "tracing",
+ "url",
+ "wasmtimer",
 ]
 
 [[package]]
@@ -347,7 +551,7 @@ checksum = "83aa984386deda02482660aa31cb8ca1e63d533f1c31a52d7d181ac5ec68e9b8"
 dependencies = [
  "alloy-consensus 0.3.6",
  "alloy-eips 0.3.6",
- "alloy-network-primitives",
+ "alloy-network-primitives 0.3.6",
  "alloy-primitives 0.8.8",
  "alloy-rlp",
  "alloy-serde 0.3.6",
@@ -355,6 +559,25 @@ dependencies = [
  "cfg-if",
  "derive_more 1.0.0",
  "hashbrown 0.14.5",
+ "itertools 0.13.0",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-rpc-types-eth"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b034779a4850b4b03f5be5ea674a1cf7d746b2da762b34d1860ab45e48ca27"
+dependencies = [
+ "alloy-consensus 0.5.4",
+ "alloy-eips 0.5.4",
+ "alloy-network-primitives 0.5.4",
+ "alloy-primitives 0.8.8",
+ "alloy-rlp",
+ "alloy-serde 0.5.4",
+ "alloy-sol-types 0.8.8",
+ "derive_more 1.0.0",
  "itertools 0.13.0",
  "serde",
  "serde_json",
@@ -383,6 +606,31 @@ dependencies = [
  "alloy-primitives 0.8.8",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028e72eaa9703e4882344983cfe7636ce06d8cce104a78ea62fd19b46659efc4"
+dependencies = [
+ "alloy-primitives 0.8.8",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-signer"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "592c185d7100258c041afac51877660c7bf6213447999787197db4842f0e938e"
+dependencies = [
+ "alloy-primitives 0.8.8",
+ "async-trait",
+ "auto_impl",
+ "elliptic-curve 0.13.8",
+ "k256 0.13.4",
+ "thiserror",
 ]
 
 [[package]]
@@ -480,6 +728,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-sol-type-parser"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45d1fbee9e698f3ba176b6e7a145f4aefe6d2b746b611e8bb246fe11a0e9f6c4"
+dependencies = [
+ "serde",
+ "winnow",
+]
+
+[[package]]
 name = "alloy-sol-types"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,9 +754,46 @@ version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2841af22d99e2c0f82a78fe107b6481be3dd20b89bfb067290092794734343a"
 dependencies = [
+ "alloy-json-abi",
  "alloy-primitives 0.8.8",
  "alloy-sol-macro 0.8.8",
  "const-hex",
+ "serde",
+]
+
+[[package]]
+name = "alloy-transport"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be77579633ebbc1266ae6fd7694f75c408beb1aeb6865d0b18f22893c265a061"
+dependencies = [
+ "alloy-json-rpc",
+ "base64 0.22.1",
+ "futures-util",
+ "futures-utils-wasm",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tower 0.5.1",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-transport-http"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91fd1a5d0827939847983b46f2f79510361f901dc82f8e3c38ac7397af142c6e"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-transport",
+ "reqwest",
+ "serde_json",
+ "tower 0.5.1",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -2272,6 +2567,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-utils-wasm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2375,6 +2676,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+
+[[package]]
+name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -2390,6 +2697,8 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
  "serde",
 ]
@@ -2420,6 +2729,10 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 name = "helix-api"
 version = "0.0.1"
 dependencies = [
+ "alloy-contract",
+ "alloy-provider",
+ "alloy-sol-types 0.8.8",
+ "alloy-transport",
  "async-trait",
  "auto_impl",
  "axum 0.7.7",
@@ -3144,6 +3457,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.0",
+]
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3493,7 +3815,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e281fbfc2198b7c0c16457d6524f83d192662bc9f3df70f24c3038d4521616df"
 dependencies = [
  "alloy-eips 0.3.6",
- "alloy-network-primitives",
+ "alloy-network-primitives 0.3.6",
  "alloy-primitives 0.8.8",
  "alloy-rpc-types-eth 0.3.6",
  "alloy-serde 0.3.6",
@@ -4897,6 +5219,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
 dependencies = [
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "schnellru"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9a8ef13a93c54d20580de1e5c413e624e53121d42fc7e2c11d10ef7f8b02367"
+dependencies = [
+ "ahash",
+ "cfg-if",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -6472,6 +6805,20 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasmtimer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7ed9d8b15c7fb594d72bfb4b5a276f3d2029333cd93a932f376f5937f6f80ee"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,12 @@ chrono = "0.4.38"
 ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus", rev = "cf3c404043230559660810bc0c9d6d5a8498d819" }
 reth-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.0.7" }
 
+# Alloy rust types
+alloy-sol-types = "0.8.8"
+alloy-contract ="0.5.2"
+alloy-provider = { version = "0.5.2", features = ["reqwest"], default-features = false }
+alloy-transport = "0.5.2"
+
 # Logging
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -40,6 +40,10 @@ redis.workspace = true
 # Ethereum Types
 reth-primitives.workspace = true
 ethereum-consensus.workspace = true
+alloy-sol-types.workspace = true
+alloy-contract.workspace = true
+alloy-provider.workspace = true
+alloy-transport.workspace = true
 
 # Testing and Mocking
 serial_test.workspace = true

--- a/crates/api/src/constraints/api.rs
+++ b/crates/api/src/constraints/api.rs
@@ -29,7 +29,7 @@ use uuid::Uuid;
 
 use crate::constraints::error::ConstraintsApiError;
 
-pub(crate) const MAX_GATEWAY_ELECTION_SIZE: usize = 1024 * 1024; // TODO: this should be a fixed size that we calc
+// pub(crate) const MAX_GATEWAY_ELECTION_SIZE: usize = 1024 * 1024; // TODO: this should be a fixed size that we calc
 pub(crate) const MAX_SET_CONSTRAINTS_SIZE: usize = 1024 * 1024; // TODO: this should be a fixed size that we calc
 
 /// Information about the current head slot and next elected gateway.

--- a/crates/api/src/delegation/contract_delegation.rs
+++ b/crates/api/src/delegation/contract_delegation.rs
@@ -1,0 +1,80 @@
+use std::sync::Arc;
+
+use alloy_provider::{
+    fillers::{BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller},
+    network::Ethereum,
+    Identity, RootProvider,
+};
+use alloy_sol_types::sol;
+use alloy_transport::BoxTransport;
+use ethereum_consensus::primitives::{BlsPublicKey, BlsSignature};
+use helix_common::api::constraints_api::{PreconferElection, SignedPreconferElection};
+use reth_primitives::{Address, Bytes};
+use TaiyiCore::TaiyiCoreInstance;
+
+use super::{error::Error, traits::DelegationTrait};
+
+const DEFAULT_GAS_LIMIT: u64 = 100_000;
+
+type RecommendProvider = FillProvider<
+    JoinFill<Identity, JoinFill<GasFiller, JoinFill<BlobGasFiller, JoinFill<NonceFiller, ChainIdFiller>>>>,
+    RootProvider<BoxTransport>,
+    BoxTransport,
+    Ethereum,
+>;
+
+// solidity codes from https://github.com/lu-bann/taiyi/blob/b3dc7487e3c6b7e75b5223bcd36155f93cf74ea3/contracts/src/interfaces/IDelegationContract.sol#L36-L41
+sol! {
+    #[derive(Debug)]
+    struct PreconferElectionRes {
+        bytes validatorPubkey;
+        bytes preconferPubkey;
+        uint256 chainId;
+        address preconferAddress;
+    }
+
+    #[sol(rpc)]
+    contract TaiyiCore {
+        #[derive(Debug)]
+        function getPreconferElection(bytes calldata validatorPubKey) external view returns (PreconferElectionRes memory);
+    }
+}
+
+#[derive(Clone)]
+pub struct ContractDelegation {
+    delegation_contract_address: Address,
+    provider: RecommendProvider,
+}
+
+impl ContractDelegation {
+    pub fn new(delegation_contract_address: Address, provider: RecommendProvider) -> Self {
+        Self { delegation_contract_address, provider }
+    }
+}
+
+#[async_trait::async_trait]
+impl DelegationTrait for ContractDelegation {
+    async fn get_preconfer_election(&self, validator_pubkey: &BlsPublicKey, slot: u64) -> Result<Option<SignedPreconferElection>, Error> {
+        let pubkey = Bytes::from(validator_pubkey.as_ref().to_vec());
+        let taiyi_core_contract = Arc::new(TaiyiCoreInstance::new(self.delegation_contract_address, self.provider.clone()));
+        let preconfer_election =
+            taiyi_core_contract.getPreconferElection(pubkey).call().await.map_err(|e| Error::GetPreconferElection(e.to_string()))?;
+        if preconfer_election._0.preconferAddress.is_zero() {
+            return Ok(None);
+        }
+        let signed_preconfer_election = SignedPreconferElection {
+            message: PreconferElection {
+                slot_number: slot,
+                preconfer_pubkey: BlsPublicKey::try_from(preconfer_election._0.preconferPubkey.as_ref())
+                    .map_err(|e| Error::BlsPublicKey(e.to_string()))?,
+                proposer_pubkey: BlsPublicKey::try_from(preconfer_election._0.validatorPubkey.as_ref())
+                    .map_err(|e| Error::BlsPublicKey(e.to_string()))?,
+                chain_id: preconfer_election._0.chainId.to(),
+                // gas limit is not used
+                gas_limit: DEFAULT_GAS_LIMIT,
+            },
+            signature: BlsSignature::default(),
+        };
+        Ok(Some(signed_preconfer_election))
+    }
+}

--- a/crates/api/src/delegation/error.rs
+++ b/crates/api/src/delegation/error.rs
@@ -1,0 +1,7 @@
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("error getting preconfer election: {0}")]
+    GetPreconferElection(String),
+    #[error("error parsing bls public key: {0}")]
+    BlsPublicKey(String),
+}

--- a/crates/api/src/delegation/mock_delegation.rs
+++ b/crates/api/src/delegation/mock_delegation.rs
@@ -1,0 +1,15 @@
+use async_trait::async_trait;
+use ethereum_consensus::primitives::BlsPublicKey;
+use helix_common::api::constraints_api::SignedPreconferElection;
+
+use super::{error::Error, traits::DelegationTrait};
+
+#[derive(Clone, Default)]
+pub struct MockDelegation {}
+
+#[async_trait]
+impl DelegationTrait for MockDelegation {
+    async fn get_preconfer_election(&self, _validator_pubkey: &BlsPublicKey, _slot: u64) -> Result<Option<SignedPreconferElection>, Error> {
+        Ok(None)
+    }
+}

--- a/crates/api/src/delegation/mod.rs
+++ b/crates/api/src/delegation/mod.rs
@@ -1,0 +1,7 @@
+pub mod contract_delegation;
+pub mod error;
+pub mod mock_delegation;
+pub mod traits;
+
+pub use contract_delegation::ContractDelegation;
+pub use mock_delegation::MockDelegation;

--- a/crates/api/src/delegation/traits.rs
+++ b/crates/api/src/delegation/traits.rs
@@ -1,0 +1,11 @@
+use async_trait::async_trait;
+use ethereum_consensus::primitives::BlsPublicKey;
+use helix_common::api::constraints_api::SignedPreconferElection;
+
+use super::error::Error;
+
+#[async_trait]
+#[auto_impl::auto_impl(Arc)]
+pub trait DelegationTrait: Send + Sync + Clone {
+    async fn get_preconfer_election(&self, validator_pubkey: &BlsPublicKey, slot: u64) -> Result<Option<SignedPreconferElection>, Error>;
+}

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod builder;
 pub mod constraints;
+pub mod delegation;
 pub mod gossiper;
 pub mod integration_tests;
 pub mod middleware;

--- a/crates/api/src/proposer/api.rs
+++ b/crates/api/src/proposer/api.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::type_complexity)]
 use std::{
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -31,7 +32,7 @@ use helix_common::{
     deneb::{BlobSidecars, BuildBlobSidecarError},
     get_genesis_time_with_delay,
     signed_proposal::VersionedSignedProposal,
-    traces::constraints_api::{ElectGatewayTrace, SetConstraintsTrace},
+    traces::constraints_api::SetConstraintsTrace,
     try_execution_header_from_payload,
     versioned_payload::PayloadAndBlobs,
     BidRequest, Filtering, GetHeaderTrace, GetPayloadTrace, RegisterValidatorsTrace, ValidatorPreferences,
@@ -39,7 +40,7 @@ use helix_common::{
 use helix_database::DatabaseService;
 use helix_datastore::{constraints::ConstraintsAuctioneer, error::AuctioneerError, Auctioneer};
 use helix_housekeeper::{ChainUpdate, SlotUpdate};
-use helix_utils::signing::{verify_signed_builder_message, verify_signed_commit_boost_message, verify_signed_consensus_message};
+use helix_utils::signing::{verify_signed_builder_message, verify_signed_consensus_message};
 use tokio::{
     sync::{
         mpsc::{self, error::SendError, Receiver, Sender},
@@ -51,10 +52,8 @@ use tracing::{debug, error, info, trace, warn};
 use uuid::Uuid;
 
 use crate::{
-    constraints::{
-        api::{MAX_GATEWAY_ELECTION_SIZE, MAX_SET_CONSTRAINTS_SIZE},
-        SET_CONSTRAINTS_CUTOFF_NS,
-    },
+    constraints::{api::MAX_SET_CONSTRAINTS_SIZE, SET_CONSTRAINTS_CUTOFF_NS},
+    delegation::traits::DelegationTrait,
     gossiper::{
         traits::GossipClientTrait,
         types::{BroadcastGetPayloadParams, GossipedMessage},
@@ -73,12 +72,13 @@ struct SlotInfo {
 }
 
 #[derive(Clone)]
-pub struct ProposerApi<A, DB, M, G>
+pub struct ProposerApi<A, DB, M, G, D>
 where
     A: Auctioneer + ConstraintsAuctioneer,
     DB: DatabaseService,
     M: MultiBeaconClientTrait,
     G: GossipClientTrait + 'static,
+    D: DelegationTrait,
 {
     auctioneer: Arc<A>,
     db: Arc<DB>,
@@ -94,14 +94,17 @@ where
     validator_preferences: Arc<ValidatorPreferences>,
 
     target_get_payload_propagation_duration_ms: u64,
+
+    delegation_contract: Arc<D>,
 }
 
-impl<A, DB, M, G> ProposerApi<A, DB, M, G>
+impl<A, DB, M, G, D> ProposerApi<A, DB, M, G, D>
 where
     A: Auctioneer + ConstraintsAuctioneer + 'static,
     DB: DatabaseService + 'static,
     M: MultiBeaconClientTrait + 'static,
     G: GossipClientTrait + 'static,
+    D: DelegationTrait + 'static,
 {
     pub fn new(
         auctioneer: Arc<A>,
@@ -114,6 +117,7 @@ where
         validator_preferences: Arc<ValidatorPreferences>,
         target_get_payload_propagation_duration_ms: u64,
         gossip_receiver: Receiver<GossipedMessage>,
+        delegation_contract: Arc<D>,
     ) -> Self {
         let api = Self {
             auctioneer,
@@ -126,6 +130,7 @@ where
             chain_info,
             validator_preferences,
             target_get_payload_propagation_duration_ms,
+            delegation_contract,
         };
 
         // Spin up gossip processing task
@@ -149,7 +154,7 @@ where
     }
 
     /// Implements this API: <https://ethereum.github.io/builder-specs/#/Builder/status>
-    pub async fn status(Extension(_proposer_api): Extension<Arc<ProposerApi<A, DB, M, G>>>) -> Result<impl IntoResponse, ProposerApiError> {
+    pub async fn status(Extension(_proposer_api): Extension<Arc<ProposerApi<A, DB, M, G, D>>>) -> Result<impl IntoResponse, ProposerApiError> {
         Ok(StatusCode::OK)
     }
 
@@ -166,7 +171,7 @@ where
     ///
     /// Implements this API: <https://ethereum.github.io/builder-specs/#/Builder/registerValidator>
     pub async fn register_validators(
-        Extension(proposer_api): Extension<Arc<ProposerApi<A, DB, M, G>>>,
+        Extension(proposer_api): Extension<Arc<ProposerApi<A, DB, M, G, D>>>,
         headers: HeaderMap,
         req: Request<Body>,
     ) -> Result<StatusCode, ProposerApiError> {
@@ -367,7 +372,7 @@ where
     ///
     /// Implements this API: <https://ethereum.github.io/builder-specs/#/Builder/getHeader>
     pub async fn get_header(
-        Extension(proposer_api): Extension<Arc<ProposerApi<A, DB, M, G>>>,
+        Extension(proposer_api): Extension<Arc<ProposerApi<A, DB, M, G, D>>>,
         Path(GetHeaderParams { slot, parent_hash, public_key }): Path<GetHeaderParams>,
     ) -> Result<impl IntoResponse, ProposerApiError> {
         let request_id = Uuid::new_v4();
@@ -448,7 +453,7 @@ where
     ///
     /// Implements this API: <https://ethereum.github.io/builder-specs/#/Builder/submitBlindedBlock>
     pub async fn get_payload(
-        Extension(proposer_api): Extension<Arc<ProposerApi<A, DB, M, G>>>,
+        Extension(proposer_api): Extension<Arc<ProposerApi<A, DB, M, G, D>>>,
         req: Request<Body>,
     ) -> Result<impl IntoResponse, ProposerApiError> {
         let mut trace = GetPayloadTrace { receive: get_nanos_timestamp()?, ..Default::default() };
@@ -727,7 +732,7 @@ where
     /// If the request is sent by the preconfer for this current slot and this is the first time, we save the constraints.
     /// Must also be sent before the cutoff.
     pub async fn set_constraints(
-        Extension(proposer_api): Extension<Arc<ProposerApi<A, DB, M, G>>>,
+        Extension(proposer_api): Extension<Arc<ProposerApi<A, DB, M, G, D>>>,
         req: Request<Body>,
     ) -> Result<StatusCode, ProposerApiError> {
         let request_id = Uuid::new_v4();
@@ -785,45 +790,45 @@ where
         Ok(StatusCode::OK)
     }
 
-    /// Elects a gateway to perform pre-confirmations for a validator. The request must be signed by the validator
-    /// and must be for the next epoch.
-    pub async fn elect_preconfer(
-        Extension(proposer_api): Extension<Arc<ProposerApi<A, DB, M, G>>>,
-        req: Request<Body>,
-    ) -> Result<StatusCode, ProposerApiError> {
-        let request_id = Uuid::new_v4();
-        let mut trace = ElectGatewayTrace { receive: get_nanos_timestamp()?, ..Default::default() };
+    // /// Elects a gateway to perform pre-confirmations for a validator. The request must be signed by the validator
+    // /// and must be for the next epoch.
+    // pub async fn elect_preconfer(
+    //     Extension(proposer_api): Extension<Arc<ProposerApi<A, DB, M, G>>>,
+    //     req: Request<Body>,
+    // ) -> Result<StatusCode, ProposerApiError> {
+    //     let request_id = Uuid::new_v4();
+    //     let mut trace = ElectGatewayTrace { receive: get_nanos_timestamp()?, ..Default::default() };
 
-        // Deserialise request
-        let mut election_req: SignedPreconferElection = deserialize_json_request_bytes(req, MAX_GATEWAY_ELECTION_SIZE).await?;
-        trace.deserialize = get_nanos_timestamp()?;
+    //     // Deserialise request
+    //     let mut election_req: SignedPreconferElection = deserialize_json_request_bytes(req, MAX_GATEWAY_ELECTION_SIZE).await?;
+    //     trace.deserialize = get_nanos_timestamp()?;
 
-        let slot_info = proposer_api.curr_slot_info.read().await;
-        info!(
-            request_id = %request_id,
-            event = "elect_gateway",
-            head_slot = slot_info.slot,
-            request_ts = trace.receive,
-            slot = %election_req.slot(),
-            preconfer_public_key = ?election_req.preconfer_public_key(),
-            gas_limit = election_req.gas_limit(),
-            chain_id = election_req.chain_id(),
-        );
+    //     let slot_info = proposer_api.curr_slot_info.read().await;
+    //     info!(
+    //         request_id = %request_id,
+    //         event = "elect_gateway",
+    //         head_slot = slot_info.slot,
+    //         request_ts = trace.receive,
+    //         slot = %election_req.slot(),
+    //         preconfer_public_key = ?election_req.preconfer_public_key(),
+    //         gas_limit = election_req.gas_limit(),
+    //         chain_id = election_req.chain_id(),
+    //     );
 
-        if let Err(err) = proposer_api.validate_election_request(&mut election_req, slot_info.slot).await {
-            warn!(request_id = %request_id, ?err, "validation failed");
-            return Err(err);
-        }
-        trace.validation_complete = get_nanos_timestamp()?;
+    //     if let Err(err) = proposer_api.validate_election_request(&mut election_req, slot_info.slot).await {
+    //         warn!(request_id = %request_id, ?err, "validation failed");
+    //         return Err(err);
+    //     }
+    //     trace.validation_complete = get_nanos_timestamp()?;
 
-        // Save to constraints datastore
-        // TODO: database
-        proposer_api.auctioneer.save_new_gateway_election(&election_req, election_req.slot()).await?;
-        trace.gateway_election_saved = get_nanos_timestamp()?;
+    //     // Save to constraints datastore
+    //     // TODO: database
+    //     proposer_api.auctioneer.save_new_gateway_election(&election_req, election_req.slot()).await?;
+    //     trace.gateway_election_saved = get_nanos_timestamp()?;
 
-        info!(%request_id, ?trace, "gateway elected");
-        Ok(StatusCode::OK)
-    }
+    //     info!(%request_id, ?trace, "gateway elected");
+    //     Ok(StatusCode::OK)
+    // }
 
     /// - Ensures the constraints can only be set for the current epoch.
     /// - Checks that the constraints are set within the allowed time window.
@@ -868,61 +873,16 @@ where
 
         Ok(())
     }
-
-    /// - Checks if the requested slot is in the past.
-    /// - Checks if the requested slot is for epoch+1.
-    /// - Retrieves the latest known proposer duty.
-    /// - Ensures the request slot is not beyond the latest known proposer duty.
-    /// - Validates that the provided public key is the proposer for the requested slot.
-    /// - Verifies the signature.
-    async fn validate_election_request(&self, election_req: &mut SignedPreconferElection, head_slot: u64) -> Result<(), ProposerApiError> {
-        // Cannot elect a gateway for a past slot
-        if election_req.slot() <= head_slot {
-            return Err(ProposerApiError::RequestForPastSlot { request_slot: election_req.slot(), head_slot });
-        }
-
-        // Ensure the requested slot is for the next epoch
-        let head_epoch = head_slot / SLOTS_PER_EPOCH;
-        let request_epoch = election_req.slot() / SLOTS_PER_EPOCH;
-        if request_epoch != head_epoch + 1 {
-            return Err(ProposerApiError::ElectPreconferRequestForInvalidEpoch { request_epoch, head_epoch });
-        }
-
-        let duties_read_guard = self.proposer_duties.read().await;
-
-        // Ensure provided validator public key is the proposer for the requested slot.
-        let proposer_pub_key = match duties_read_guard.iter().find(|duty| duty.slot == election_req.slot()) {
-            Some(slot_duty) => slot_duty.entry.registration.message.public_key.clone(),
-            None => {
-                return Err(ProposerApiError::ProposerDutyNotFound { slot: election_req.slot() });
-            }
-        };
-
-        // Drop the read lock guard to avoid holding it during signature verification
-        drop(duties_read_guard);
-
-        // Verify commit boost signature
-        if let Err(err) = verify_signed_commit_boost_message(
-            &mut election_req.message,
-            &election_req.signature,
-            &proposer_pub_key,
-            Some(self.chain_info.genesis_validators_root),
-            &self.chain_info.context,
-        ) {
-            return Err(ProposerApiError::InvalidSignature(err));
-        }
-
-        Ok(())
-    }
 }
 
 // HELPERS
-impl<A, DB, M, G> ProposerApi<A, DB, M, G>
+impl<A, DB, M, G, D> ProposerApi<A, DB, M, G, D>
 where
     A: Auctioneer + ConstraintsAuctioneer + 'static,
     DB: DatabaseService + 'static,
     M: MultiBeaconClientTrait + 'static,
     G: GossipClientTrait + 'static,
+    D: DelegationTrait + 'static,
 {
     /// Validate a single registration.
     pub fn validate_registration(&self, registration: &mut SignedValidatorRegistration) -> Result<(), ProposerApiError> {
@@ -1274,12 +1234,13 @@ async fn deserialize_get_payload_bytes(req: Request<Body>) -> Result<SignedBlind
 }
 
 // STATE SYNC
-impl<A, DB, M, G> ProposerApi<A, DB, M, G>
+impl<A, DB, M, G, D> ProposerApi<A, DB, M, G, D>
 where
     A: Auctioneer + ConstraintsAuctioneer,
     DB: DatabaseService,
     M: MultiBeaconClientTrait,
     G: GossipClientTrait + 'static,
+    D: DelegationTrait + 'static,
 {
     /// Subscribes to slot head updater.
     /// Updates the current slot and next proposer duty.
@@ -1313,6 +1274,29 @@ where
 
         // Update duties if applicable
         if let Some(new_duties) = slot_update.new_duties {
+            for duty in new_duties.iter() {
+                match self.delegation_contract.get_preconfer_election(&duty.entry.registration.message.public_key, duty.slot).await {
+                    Ok(Some(elected_preconfer)) => match self.auctioneer.save_new_gateway_election(&elected_preconfer, duty.slot).await {
+                        Ok(_) => {
+                            debug!(
+                                slot = duty.slot,
+                                pub_key = duty.entry.registration.message.public_key.to_string(),
+                                preconfer = elected_preconfer.message.preconfer_pubkey.to_string(),
+                                "elected preconfer"
+                            );
+                        }
+                        Err(err) => {
+                            error!(slot = duty.slot, pub_key = duty.entry.registration.message.public_key.to_string(), error = %err, "error saving new gateway election");
+                        }
+                    },
+                    Ok(None) => {
+                        debug!(slot = duty.slot, pub_key = duty.entry.registration.message.public_key.to_string(), "no elected preconfer");
+                    }
+                    Err(err) => {
+                        error!(slot = duty.slot, pub_key = duty.entry.registration.message.public_key.to_string(), error = %err, "error getting preconfer election");
+                    }
+                }
+            }
             *self.proposer_duties.write().await = new_duties;
         }
 

--- a/crates/api/src/proposer/tests.rs
+++ b/crates/api/src/proposer/tests.rs
@@ -70,6 +70,7 @@ mod proposer_api_tests {
     };
 
     use crate::{
+        delegation::mock_delegation::MockDelegation,
         gossiper::{mock_gossiper::MockGossiper, types::GossipedMessage},
         proposer::{
             api::{get_nanos_timestamp, ProposerApi},
@@ -204,7 +205,7 @@ mod proposer_api_tests {
     async fn start_api_server() -> (
         oneshot::Sender<()>,
         HttpServiceConfig,
-        Arc<ProposerApi<MockAuctioneer, MockDatabaseService, MockMultiBeaconClient, MockGossiper>>,
+        Arc<ProposerApi<MockAuctioneer, MockDatabaseService, MockMultiBeaconClient, MockGossiper, MockDelegation>>,
         Receiver<Sender<ChainUpdate>>,
         Arc<MockAuctioneer>,
     ) {
@@ -825,7 +826,7 @@ mod proposer_api_tests {
         let (_gossip_sender, gossip_receiver) = channel::<GossipedMessage>(32);
         let auctioneer = Arc::new(MockAuctioneer::default());
 
-        let prop_api = ProposerApi::<MockAuctioneer, MockDatabaseService, MockMultiBeaconClient, MockGossiper>::new(
+        let prop_api = ProposerApi::<MockAuctioneer, MockDatabaseService, MockMultiBeaconClient, MockGossiper, MockDelegation>::new(
             auctioneer.clone(),
             Arc::new(MockDatabaseService::default()),
             Arc::new(MockGossiper::new().unwrap()),
@@ -836,6 +837,7 @@ mod proposer_api_tests {
             Arc::new(ValidatorPreferences::default()),
             0,
             gossip_receiver,
+            Arc::new(MockDelegation::default()),
         );
 
         let mut x = gen_signed_vr();

--- a/crates/api/src/router.rs
+++ b/crates/api/src/router.rs
@@ -20,6 +20,7 @@ use crate::{
         optimistic_simulator::OptimisticSimulator,
     },
     constraints::api::ConstraintsApi,
+    delegation::ContractDelegation,
     gossiper::grpc_gossiper::GrpcGossiperClientManager,
     middleware::rate_limiting::rate_limit_by_ip::{rate_limit_by_ip, RateLimitState, RateLimitStateForRoute},
     proposer::api::ProposerApi,
@@ -30,7 +31,8 @@ use crate::{
 pub type BuilderApiProd =
     BuilderApi<RedisCache, PostgresDatabaseService, OptimisticSimulator<RedisCache, PostgresDatabaseService>, GrpcGossiperClientManager>;
 
-pub type ProposerApiProd = ProposerApi<RedisCache, PostgresDatabaseService, MultiBeaconClient<BeaconClient>, GrpcGossiperClientManager>;
+pub type ProposerApiProd =
+    ProposerApi<RedisCache, PostgresDatabaseService, MultiBeaconClient<BeaconClient>, GrpcGossiperClientManager, ContractDelegation>;
 
 pub type DataApiProd = DataApi<PostgresDatabaseService>;
 
@@ -91,9 +93,9 @@ pub fn build_router(
             Route::SetConstraints => {
                 router = router.route(&route.path(), post(ProposerApiProd::set_constraints));
             }
-            Route::ElectPreconfer => {
-                router = router.route(&route.path(), post(ProposerApiProd::elect_preconfer));
-            }
+            // Route::ElectPreconfer => {
+            //     router = router.route(&route.path(), post(ProposerApiProd::elect_preconfer));
+            // }
             Route::ProposerPayloadDelivered => {
                 router = router.route(&route.path(), get(DataApiProd::proposer_payload_delivered));
             }

--- a/crates/api/src/service.rs
+++ b/crates/api/src/service.rs
@@ -1,5 +1,6 @@
 use std::{env, net::SocketAddr, sync::Arc, time::Duration};
 
+use alloy_provider::ProviderBuilder;
 use ethereum_consensus::crypto::SecretKey;
 use helix_beacon_client::{
     beacon_client::BeaconClient, fiber_broadcaster::FiberBroadcaster, multi_beacon_client::MultiBeaconClient, BlockBroadcaster,
@@ -18,6 +19,7 @@ use tracing::{error, info};
 
 use crate::{
     builder::optimistic_simulator::OptimisticSimulator,
+    delegation::ContractDelegation,
     gossiper::grpc_gossiper::GrpcGossiperClientManager,
     relay_data::{BidsCache, DeliveredPayloadsCache},
     router::{build_router, BuilderApiProd, ConstraintsApiProd, DataApiProd, ProposerApiProd},
@@ -140,6 +142,13 @@ impl ApiService {
 
         let validator_preferences = Arc::new(config.validator_preferences.clone());
 
+        let provider = ProviderBuilder::new()
+            .with_recommended_fillers()
+            .on_builtin(config.execution_clients.url.clone().as_str())
+            .await
+            .expect("execution client provider init failed");
+        let delegation_contract = Arc::new(ContractDelegation::new(config.onchain_delegation.delegation_contract_address, provider));
+
         let proposer_api = Arc::new(ProposerApiProd::new(
             auctioneer.clone(),
             db.clone(),
@@ -151,6 +160,7 @@ impl ApiService {
             validator_preferences.clone(),
             config.target_get_payload_propagation_duration_ms,
             proposer_gossip_receiver,
+            delegation_contract,
         ));
 
         let data_api = Arc::new(DataApiProd::new(validator_preferences.clone(), db.clone()));

--- a/crates/api/src/test_utils.rs
+++ b/crates/api/src/test_utils.rs
@@ -21,6 +21,7 @@ use crate::{
         mock_simulator::MockSimulator,
     },
     constraints::{api::ConstraintsApi, types::*},
+    delegation::MockDelegation,
     gossiper::{mock_gossiper::MockGossiper, types::GossipedMessage},
     proposer::{
         api::{ProposerApi, MAX_BLINDED_BLOCK_LENGTH, MAX_VAL_REGISTRATIONS_LENGTH},
@@ -33,7 +34,7 @@ pub fn app() -> Router {
     let (slot_update_sender, _slot_update_receiver) = channel::<Sender<ChainUpdate>>(32);
     let (_gossip_sender, gossip_receiver) = channel::<GossipedMessage>(32);
 
-    let api_service = Arc::new(ProposerApi::<MockAuctioneer, MockDatabaseService, MockMultiBeaconClient, MockGossiper>::new(
+    let api_service = Arc::new(ProposerApi::<MockAuctioneer, MockDatabaseService, MockMultiBeaconClient, MockGossiper, MockDelegation>::new(
         Arc::new(MockAuctioneer::default()),
         Arc::new(MockDatabaseService::default()),
         Arc::new(MockGossiper::new().unwrap()),
@@ -44,6 +45,7 @@ pub fn app() -> Router {
         Arc::new(ValidatorPreferences::default()),
         0,
         gossip_receiver,
+        Arc::new(MockDelegation::default()),
     ));
 
     let data_api = Arc::new(DataApi::<MockDatabaseService>::new(Arc::new(ValidatorPreferences::default()), Arc::new(MockDatabaseService::default())));
@@ -51,19 +53,19 @@ pub fn app() -> Router {
     Router::new()
         .route(
             &format!("{PATH_PROPOSER_API}{PATH_STATUS}"),
-            get(ProposerApi::<MockAuctioneer, MockDatabaseService, MockMultiBeaconClient, MockGossiper>::status),
+            get(ProposerApi::<MockAuctioneer, MockDatabaseService, MockMultiBeaconClient, MockGossiper, MockDelegation>::status),
         )
         .route(
             &format!("{PATH_PROPOSER_API}{PATH_REGISTER_VALIDATORS}"),
-            post(ProposerApi::<MockAuctioneer, MockDatabaseService, MockMultiBeaconClient, MockGossiper>::register_validators),
+            post(ProposerApi::<MockAuctioneer, MockDatabaseService, MockMultiBeaconClient, MockGossiper, MockDelegation>::register_validators),
         )
         .route(
             &format!("{PATH_PROPOSER_API}{PATH_GET_HEADER}"),
-            get(ProposerApi::<MockAuctioneer, MockDatabaseService, MockMultiBeaconClient, MockGossiper>::get_header),
+            get(ProposerApi::<MockAuctioneer, MockDatabaseService, MockMultiBeaconClient, MockGossiper, MockDelegation>::get_header),
         )
         .route(
             &format!("{PATH_PROPOSER_API}{PATH_GET_PAYLOAD}"),
-            post(ProposerApi::<MockAuctioneer, MockDatabaseService, MockMultiBeaconClient, MockGossiper>::get_payload),
+            post(ProposerApi::<MockAuctioneer, MockDatabaseService, MockMultiBeaconClient, MockGossiper, MockDelegation>::get_payload),
         )
         .route(&format!("{PATH_DATA_API}{PATH_PROPOSER_PAYLOAD_DELIVERED}"), get(DataApi::<MockDatabaseService>::proposer_payload_delivered))
         .route(&format!("{PATH_DATA_API}{PATH_BUILDER_BIDS_RECEIVED}"), get(DataApi::<MockDatabaseService>::builder_bids_received))
@@ -112,39 +114,41 @@ pub fn builder_api_app() -> (Router, Arc<BuilderApi<MockAuctioneer, MockDatabase
 
 pub fn proposer_api_app() -> (
     Router,
-    Arc<ProposerApi<MockAuctioneer, MockDatabaseService, MockMultiBeaconClient, MockGossiper>>,
+    Arc<ProposerApi<MockAuctioneer, MockDatabaseService, MockMultiBeaconClient, MockGossiper, MockDelegation>>,
     Receiver<Sender<ChainUpdate>>,
     Arc<MockAuctioneer>,
 ) {
     let (slot_update_sender, slot_update_receiver) = channel::<Sender<ChainUpdate>>(32);
     let (_gossip_sender, gossip_receiver) = channel::<GossipedMessage>(32);
     let auctioneer = Arc::new(MockAuctioneer::default());
-    let proposer_api_service = Arc::new(ProposerApi::<MockAuctioneer, MockDatabaseService, MockMultiBeaconClient, MockGossiper>::new(
-        auctioneer.clone(),
-        Arc::new(MockDatabaseService::default()),
-        Arc::new(MockGossiper::new().unwrap()),
-        vec![Arc::new(BlockBroadcaster::Mock(MockBlockBroadcaster::default()))],
-        Arc::new(MockMultiBeaconClient::default()),
-        Arc::new(ChainInfo::for_mainnet()),
-        slot_update_sender.clone(),
-        Arc::new(ValidatorPreferences::default()),
-        0,
-        gossip_receiver,
-    ));
+    let proposer_api_service =
+        Arc::new(ProposerApi::<MockAuctioneer, MockDatabaseService, MockMultiBeaconClient, MockGossiper, MockDelegation>::new(
+            auctioneer.clone(),
+            Arc::new(MockDatabaseService::default()),
+            Arc::new(MockGossiper::new().unwrap()),
+            vec![Arc::new(BlockBroadcaster::Mock(MockBlockBroadcaster::default()))],
+            Arc::new(MockMultiBeaconClient::default()),
+            Arc::new(ChainInfo::for_mainnet()),
+            slot_update_sender.clone(),
+            Arc::new(ValidatorPreferences::default()),
+            0,
+            gossip_receiver,
+            Arc::new(MockDelegation::default()),
+        ));
 
     let router = Router::new()
         .route(
             &format!("{PATH_PROPOSER_API}{PATH_GET_HEADER}"),
-            get(ProposerApi::<MockAuctioneer, MockDatabaseService, MockMultiBeaconClient, MockGossiper>::get_header),
+            get(ProposerApi::<MockAuctioneer, MockDatabaseService, MockMultiBeaconClient, MockGossiper, MockDelegation>::get_header),
         )
         .route(
             &format!("{PATH_PROPOSER_API}{PATH_GET_PAYLOAD}"),
-            post(ProposerApi::<MockAuctioneer, MockDatabaseService, MockMultiBeaconClient, MockGossiper>::get_payload),
+            post(ProposerApi::<MockAuctioneer, MockDatabaseService, MockMultiBeaconClient, MockGossiper, MockDelegation>::get_payload),
         )
         .layer(RequestBodyLimitLayer::new(MAX_BLINDED_BLOCK_LENGTH))
         .route(
             &format!("{PATH_PROPOSER_API}{PATH_REGISTER_VALIDATORS}"),
-            post(ProposerApi::<MockAuctioneer, MockDatabaseService, MockMultiBeaconClient, MockGossiper>::register_validators),
+            post(ProposerApi::<MockAuctioneer, MockDatabaseService, MockMultiBeaconClient, MockGossiper, MockDelegation>::register_validators),
         )
         .layer(RequestBodyLimitLayer::new(MAX_VAL_REGISTRATIONS_LENGTH))
         .layer(Extension(proposer_api_service.clone()));

--- a/crates/common/src/api/constraints_api.rs
+++ b/crates/common/src/api/constraints_api.rs
@@ -45,6 +45,8 @@ impl SignedPreconferElection {
 pub struct PreconferElection {
     /// Public key of the preconfer proposing for `slot`.
     pub preconfer_pubkey: BlsPublicKey,
+    /// Proposer public key.
+    pub proposer_pubkey: BlsPublicKey,
     /// Slot this delegation is valid for.
     pub slot_number: u64,
     /// Chain ID of the chain this election is for.
@@ -57,6 +59,7 @@ impl PreconferElection {
     pub fn from_proposer_duty(duty: &BuilderGetValidatorsResponseEntry, chain_id: u64) -> Self {
         Self {
             slot_number: duty.slot,
+            proposer_pubkey: duty.entry.registration.message.public_key.clone(),
             preconfer_pubkey: duty.entry.registration.message.public_key.clone(),
             chain_id,
             gas_limit: duty.entry.registration.message.gas_limit,

--- a/crates/common/src/api/mod.rs
+++ b/crates/common/src/api/mod.rs
@@ -17,7 +17,7 @@ pub(crate) const PATH_STATUS: &str = "/status";
 pub(crate) const PATH_REGISTER_VALIDATORS: &str = "/validators";
 pub(crate) const PATH_GET_HEADER: &str = "/header/:slot/:parent_hash/:pubkey";
 pub(crate) const PATH_GET_PAYLOAD: &str = "/blinded_blocks";
-pub(crate) const PATH_ELECT_PRECONFER: &str = "/elect_preconfer";
+// pub(crate) const PATH_ELECT_PRECONFER: &str = "/elect_preconfer";
 pub(crate) const PATH_SET_CONSTRAINTS: &str = "/set_constraints";
 
 pub(crate) const PATH_DATA_API: &str = "/relay/v1/data";

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -7,6 +7,7 @@ use helix_utils::{
     serde::{default_bool, deserialize_url, serialize_url},
 };
 use reqwest::Url;
+use reth_primitives::Address;
 use serde::{Deserialize, Serialize};
 
 use crate::{api::*, ValidatorPreferences};
@@ -20,6 +21,10 @@ pub struct RelayConfig {
     pub simulator: SimulatorConfig,
     #[serde(default)]
     pub beacon_clients: Vec<BeaconClientConfig>,
+    #[serde(default)]
+    pub execution_clients: ExecutionClientConfig,
+    #[serde(default)]
+    pub onchain_delegation: OnchainDelegationConfig,
     #[serde(default)]
     pub relays: Vec<RelayGossipConfig>,
     #[serde(default)]
@@ -95,6 +100,23 @@ pub struct BeaconClientConfig {
     pub gossip_blobs_enabled: bool,
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct ExecutionClientConfig {
+    #[serde(serialize_with = "serialize_url", deserialize_with = "deserialize_url")]
+    pub url: Url,
+}
+
+impl Default for ExecutionClientConfig {
+    fn default() -> Self {
+        Self { url: Url::parse("http://localhost:8545").unwrap() }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
+pub struct OnchainDelegationConfig {
+    pub delegation_contract_address: Address,
+}
+
 #[derive(Serialize, Deserialize, Clone)]
 pub struct RelayGossipConfig {
     pub url: String,
@@ -156,7 +178,7 @@ impl RouterConfig {
             Route::SubmitHeader,
             Route::GetTopBid,
             Route::SetConstraints,
-            Route::ElectPreconfer,
+            // Route::ElectPreconfer,
         ]);
 
         self.replace_condensed_with_real(Route::ProposerApi, &[
@@ -165,7 +187,7 @@ impl RouterConfig {
             Route::GetHeader,
             Route::GetPayload,
             Route::SetConstraints,
-            Route::ElectPreconfer,
+            // Route::ElectPreconfer,
         ]);
 
         self.replace_condensed_with_real(Route::DataApi, &[
@@ -236,7 +258,7 @@ pub enum Route {
     ValidatorRegistration,
     GetConstraints,
     SetConstraints,
-    ElectPreconfer,
+    // ElectPreconfer,
     GetPreconfer,
     GetPreconfersForEpoch,
 }
@@ -255,8 +277,7 @@ impl Route {
             Route::GetHeader => format!("{PATH_PROPOSER_API}{PATH_GET_HEADER}"),
             Route::GetPayload => format!("{PATH_PROPOSER_API}{PATH_GET_PAYLOAD}"),
             Route::SetConstraints => format!("{PATH_PROPOSER_API}{PATH_SET_CONSTRAINTS}"),
-            Route::ElectPreconfer => format!("{PATH_PROPOSER_API}{PATH_ELECT_PRECONFER}"),
-
+            // Route::ElectPreconfer => format!("{PATH_PROPOSER_API}{PATH_ELECT_PRECONFER}"),
             Route::ProposerPayloadDelivered => format!("{PATH_DATA_API}{PATH_PROPOSER_PAYLOAD_DELIVERED}"),
             Route::BuilderBidsReceived => format!("{PATH_DATA_API}{PATH_BUILDER_BIDS_RECEIVED}"),
             Route::ValidatorRegistration => format!("{PATH_DATA_API}{PATH_VALIDATOR_REGISTRATION}"),

--- a/crates/utils/src/signing.rs
+++ b/crates/utils/src/signing.rs
@@ -127,6 +127,7 @@ mod tests {
     fn test_verify_cb_signature() {
         // use the following inputs:
         let message = PreconferElection {
+            proposer_pubkey: BlsPublicKey::try_from(hex::decode(VALIDATOR_PUBKEY.trim_start_matches("0x")).unwrap().as_slice()).unwrap(),
             preconfer_pubkey: BlsPublicKey::try_from(hex::decode(PRECONFER_PUBKEY.trim_start_matches("0x")).unwrap().as_slice()).unwrap(),
             slot_number: SLOT_NUMBER,
             chain_id: CHAIN_ID,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced contract delegation functionality for interacting with the TaiyiCore smart contract on Ethereum.
	- Added new configuration options for execution clients and on-chain delegation in the RelayConfig.
	- Enhanced PreconferElection struct with a proposer public key field.
	- Added a mock implementation for delegation to facilitate testing.
	- Integrated new delegation capabilities into the ProposerApi and related components.
	- Updated the API service to utilize the new delegation contract.

- **Bug Fixes**
	- Commented out the inactive `MAX_GATEWAY_ELECTION_SIZE` constant and the `/elect_preconfer` API endpoint.

- **Documentation**
	- Updated tests to reflect new delegation capabilities and ensure compatibility with existing functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->